### PR TITLE
ci: cache pip in pylint workflow

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -12,9 +12,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- use setup-python@v5 in pylint workflow
- cache pip dependencies during CI

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0a3e51644832c9e4c1ff44f70bcec