### PR TITLE
Use Python 3.13 in pylint workflow

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,16 +5,14 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.13'
+          cache: 'pip'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- simplify pylint workflow to a single Python version
- cache dependencies with setup-python `pip` cache

## Testing
- `python -m py_compile scraper_utils.py script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a4764b24832caf7e27914df26ee7