### PR TITLE
Document --state CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,11 @@ The project is more than a simple scraper. Key implementation details:
    ```bash
    export DISABLE_GOOGLE=1
    ```
-2. Run the scraper and enter a state name or abbreviation when prompted:
+2. Run the scraper. To avoid the interactive prompt, provide a state name or abbreviation:
+   ```bash
+   python3 script.py --state Texas
+   ```
+   You can also run without `--state` and enter it when prompted:
    ```bash
    python3 script.py
    ```
@@ -102,6 +106,7 @@ https://example2.appfolio.com/listings
 
 You can tweak these parameters when running `script.py`:
 
+- `--state` – state name or abbreviation to skip the interactive prompt.
 - `--target` – number of qualifying sites to collect (default: 10).
 - `--mb-min` – minimum `$1234` markers for Buildium pages (default: 21).
 - `--af-min` – minimum "apply now" phrases for AppFolio pages (default: 20).
@@ -141,6 +146,6 @@ You can tweak these parameters when running `script.py`:
 
 ```bash
 export DISABLE_GOOGLE=1
-python3 script.py
+python3 script.py --state Texas
 ```
 


### PR DESCRIPTION
## Summary
- document `--state` CLI flag that accepts a state name or abbreviation to bypass interactive input
- add non-interactive usage example and update quick start one-liner to show `--state` flag

## Testing
- `pytest -q`
- `ruff check .`
- `python3 -m py_compile script.py`


------
https://chatgpt.com/codex/tasks/task_e_68b88f8ac488832cbf4f37c440da7996